### PR TITLE
Updated reservation dialog

### DIFF
--- a/EventPlanner/src/app/offering/details-page/details-page.component.ts
+++ b/EventPlanner/src/app/offering/details-page/details-page.component.ts
@@ -284,6 +284,10 @@ export class DetailsPageComponent implements OnInit {
   }
 
   openReservationDialog(): void {
+    if(!this.isService(this.offering)){
+      return
+    }
+    
     if (!this.authService.isLoggedIn()) {
       this.snackBar.open('Please log in to make a reservation', 'Close', {
         duration: 3000,

--- a/EventPlanner/src/app/offering/reservation-dialog/reservation-dialog.component.ts
+++ b/EventPlanner/src/app/offering/reservation-dialog/reservation-dialog.component.ts
@@ -9,7 +9,6 @@ import { Inject } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ConfirmDialogComponent } from '../../layout/confirm-dialog/confirm-dialog.component';
 import { CreateReservationDTO } from '../model/create-reservation-dto.model';
-import { HttpErrorResponse } from '@angular/common/http';
 import { Reservation } from '../model/reservation.model';
 
 @Component({
@@ -80,8 +79,17 @@ onBook(): void {
       }
     });
 
+
     dialogRef.afterClosed().subscribe((confirmed: boolean) => {
       if (confirmed) {
+
+        this.snackBar.open('Processing reservation...', 'Close', {
+        duration: 3000,
+        horizontalPosition: 'center',
+        verticalPosition: 'bottom',
+        panelClass: ['warning-snackbar']
+      });
+
         let reservation : CreateReservationDTO ={
           startTime: reservationData.startTime,
           endTime: reservationData.endTime,

--- a/EventPlanner/src/app/offering/reservation-dialog/reservation-dialog.component.ts
+++ b/EventPlanner/src/app/offering/reservation-dialog/reservation-dialog.component.ts
@@ -99,7 +99,12 @@ onBook(): void {
 
         this.reservationService.createReservation(reservation).subscribe({
           next: (response: Reservation) => {
-            this.snackBar.open('Reservation successful! Email confirmation has been sent.', 'OK', { duration: 5000 });
+            if (response.status == "PENDING"){
+              this.snackBar.open('Reservation request is pending! Email confirmation will been sent.', 'OK', { duration: 5000 });
+            }
+            else{
+              this.snackBar.open('Reservation successful! Email confirmation has been sent.', 'OK', { duration: 5000 });
+            }
             this.dialogRef.close(response);
           },
           error: (err: Error) => { 


### PR DESCRIPTION
In this pull request I updated the dialog in following ways:
- User is unable to reserve a product, this is a placeholder solution where if the button is pressed nothing happens, but when the product buying is implemented, it will be changed.
- Added a snackbar for processing reservation request, and another one for different types of reservation confirmation