### PR TITLE
Implement favorites

### DIFF
--- a/EventPlanner/src/app/account/account.service.ts
+++ b/EventPlanner/src/app/account/account.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import {AuthService} from '../infrastructure/auth/auth.service';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {catchError, map, Observable, of} from 'rxjs';
 import {Event} from '../event/model/event.model';
 import {environment} from '../../env/environment';
 import { Offering } from '../offering/model/offering.model';
+import {PagedResponse} from '../event/model/paged-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -41,11 +42,15 @@ export class AccountService {
       return null;
     return this.httpClient.delete<void>(environment.apiHost+'/accounts/'+accountId+'/favourite-offerings/'+offeringId);
   }
-  getFavouriteEvents(): Observable<Event[]> {
+
+  getFavouriteEvents(page: number, pageSize: number): Observable<PagedResponse<Event>> {
     let accountId:number=this.authService.getAccountId();
     if(accountId == null)
-      return of([]);
-    return this.httpClient.get<Event[]>(environment.apiHost+'/accounts/'+accountId+'/favourite-events');
+      return of();
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', pageSize.toString());
+    return this.httpClient.get<PagedResponse<Event>>(environment.apiHost+'/accounts/'+accountId+'/favourite-events',{params});
   }
 
   getFavouriteEvent(eventId:number): Observable<Event> {

--- a/EventPlanner/src/app/account/account.service.ts
+++ b/EventPlanner/src/app/account/account.service.ts
@@ -21,14 +21,11 @@ export class AccountService {
     return this.httpClient.get<Offering[]>(environment.apiHost+'/accounts/'+accountId+'/favourite-offerings');
   }
 
-  isInFavouriteOfferings(offeringId: number): Observable<boolean> {
-    return this.getFavouriteOfferings().pipe(
-      map((offerings: Offering[]) => offerings.some(offering => offering.id === offeringId)),
-      catchError((err) => {
-        console.error('Error fetching favourite offerings:', err);
-        return of(false);
-      })
-    );
+  getFavouriteOffering(offeringId:number): Observable<Offering> {
+    let accountId:number=this.authService.getAccountId();
+    if(accountId == null)
+      return of();
+    return this.httpClient.get<Offering>(environment.apiHost+'/accounts/'+accountId+'/favourite-offerings/'+offeringId);
   }
 
   addOfferingToFavourites(offeringId:number): Observable<void> {
@@ -51,14 +48,11 @@ export class AccountService {
     return this.httpClient.get<Event[]>(environment.apiHost+'/accounts/'+accountId+'/favourite-events');
   }
 
-  isInFavouriteEvents(eventId: number): Observable<boolean> {
-    return this.getFavouriteEvents().pipe(
-      map((events: Event[]) => events.some(event => event.id === eventId)),
-      catchError((err) => {
-        console.error('Error fetching favourite events:', err);
-        return of(false);
-      })
-    );
+  getFavouriteEvent(eventId:number): Observable<Event> {
+    let accountId:number=this.authService.getAccountId();
+    if(accountId == null)
+      return of();
+    return this.httpClient.get<Event>(environment.apiHost+'/accounts/'+accountId+'/favourite-events/'+eventId);
   }
 
   addEventToFavourites(eventId:number): Observable<void> {

--- a/EventPlanner/src/app/account/account.service.ts
+++ b/EventPlanner/src/app/account/account.service.ts
@@ -15,11 +15,14 @@ export class AccountService {
   constructor(private authService:AuthService,
               private httpClient:HttpClient) { }
 
-  getFavouriteOfferings(): Observable<Offering[]> {
-    let accountId:number=this.authService.getAccountId();
+  getFavouriteOfferings(page: number, pageSize: number): Observable<PagedResponse<Offering>> {
+    let accountId: number = this.authService.getAccountId();
     if(accountId == null)
-      return of([]);
-    return this.httpClient.get<Offering[]>(environment.apiHost+'/accounts/'+accountId+'/favourite-offerings');
+      return of();
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', pageSize.toString());
+    return this.httpClient.get<PagedResponse<Offering>>(environment.apiHost + '/accounts/' + accountId + '/favourite-offerings', {params});
   }
 
   getFavouriteOffering(offeringId:number): Observable<Offering> {

--- a/EventPlanner/src/app/app-routing.module.ts
+++ b/EventPlanner/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import {UserDetailsComponent} from './user/user-details/user-details.component';
 import {EditPersonalComponent} from './user/edit-personal/edit-personal.component';
 import {EditCompanyComponent} from './user/edit-company/edit-company.component';
 import {EditEventComponent} from './event/edit-event/edit-event.component';
+import {FavouritesComponent} from './user/favourites/favourites.component';
 
 const routes: Routes = [
   {path: 'home', component: HomeComponent},
@@ -62,6 +63,7 @@ const routes: Routes = [
   {path:'edit-company',component:EditCompanyComponent, canActivate: [AuthGuard],
     data: {role: ['PROVIDER']}},
   { path: 'chat', component: ChatComponent },
+  { path: 'favourites', component: FavouritesComponent },
   { path: '', redirectTo: '/home', pathMatch: 'full' },
   { path: '**', redirectTo: '/home', pathMatch: 'full'},
 ];

--- a/EventPlanner/src/app/event/event-details/event-details.component.ts
+++ b/EventPlanner/src/app/event/event-details/event-details.component.ts
@@ -95,9 +95,7 @@ export class EventDetailsComponent implements OnInit {
       const id = +params['id'];
       this.eventService.getEvent(id).subscribe({
         next: (event: Event) => {
-          console.log(event);
           this.event=event;
-          console.log(this.loggedInUserId);
           this.owner=event.organizer.id==this.loggedInUserId;
           this.refreshAgenda();
         },
@@ -106,13 +104,17 @@ export class EventDetailsComponent implements OnInit {
           console.error('Error fetching event:', err);
         }
       });
-      this.accountService.isInFavouriteEvents(id).subscribe({
-        next: (isFavourite: boolean) => {
-          this.isFavourite = isFavourite;
+      this.accountService.getFavouriteEvent(id).subscribe({
+        next: (event:Event) => {
+          this.isFavourite = true;
         },
         error: (err) => {
-          this.snackBar.open('Error fetching favourite event','OK',{duration:5000});
-          console.error('Error fetching favourite event:', err);
+          if(err.status===404)
+            this.isFavourite = false;
+          else{
+            this.snackBar.open('Error fetching favourite event','OK',{duration:5000});
+            console.error('Error fetching favourite event:', err);
+          }
         }
       });
     })
@@ -205,8 +207,8 @@ export class EventDetailsComponent implements OnInit {
         organizerId: recipient
       }
     });
-  }  
-  
+  }
+
 
   addParticipant():void{
     this.eventService.addParticipant(this.event.id).subscribe({

--- a/EventPlanner/src/app/layout/nav-bar/nav-bar.component.html
+++ b/EventPlanner/src/app/layout/nav-bar/nav-bar.component.html
@@ -15,6 +15,10 @@
           <mat-icon>account_circle</mat-icon>
           <span>Account details</span>
         </button>
+        <button mat-menu-item [routerLink]="['favourites']">
+          <mat-icon>favorite</mat-icon>
+          <span>Favourites</span>
+        </button>
         <button mat-menu-item (click)="logout()">
           <mat-icon>logout</mat-icon>
           <span>Log out</span>

--- a/EventPlanner/src/app/user/favourites/favourites.component.css
+++ b/EventPlanner/src/app/user/favourites/favourites.component.css
@@ -1,0 +1,296 @@
+h1 {
+  font-size: 3rem;
+  font-weight: 600;
+}
+
+h2{
+  font-size: 2rem;
+
+}
+
+button[mat-stroked-button] {
+  padding: 10px 20px;
+  font-size: 16px;
+}
+
+.no-events-message{
+  text-align: center;
+  padding-top:10vh;
+  padding-bottom:10vh;
+  color: #4e4e4e;
+}
+.total-elements{
+  text-align: center;
+  padding-top: 10px;
+  color: #4e4e4e;
+}
+
+.top-events {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 20px;
+  padding-bottom:20px;
+  text-align: center;
+  z-index: 1;
+
+}
+
+.top-event-cards {
+  display: grid;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: center;
+  grid-template-columns: repeat(auto-fit,minmax(450px,450px));
+
+}
+
+.event-bg button[mat-stroked-button]{
+  border-radius: 20px;
+  border-color: #b5b3c9 !important;
+  background-color: #b5b3c9;
+  color: #241212 !important;
+  padding: 10px 20px;
+  border-width: 3px;
+  font-size: 16px;
+}
+.event-bg button[mat-stroked-button]:hover{
+  background-color: #9c9ac9;
+  border-color: #9c9ac9 !important;
+  color: #ffffff !important ;
+}
+.mat-mdc-radio-button.mat-accent{
+  --mdc-radio-selected-icon-color:#935bd4;
+  --mat-radio-checked-ripple-color: #935bd4;
+  --mdc-radio-selected-focus-icon-color: #935bd4;
+  --mdc-radio-selected-hover-icon-color: #935bd4;
+  --mdc-radio-selected-icon-color: #935bd4;
+}
+
+.offering-bg button[mat-stroked-button]{
+  border-radius: 20px;
+  border-color: #b5b3c9 !important;
+  background-color: #b5b3c9;
+  color: #241212 !important;
+  padding: 10px 20px;
+  border-width: 3px;
+  font-size: 16px;
+}
+.offering-bg button[mat-stroked-button]:hover{
+  background-color: #9c9ac9;
+  border-color: #9c9ac9 !important;
+  color: #ffffff !important ;
+}
+
+.event-filter {
+  padding:20px;
+  text-align: center;
+
+}
+
+.name-search-section {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.search-field {
+  height: fit-content;
+  width: 300px;
+}
+
+.search-button {
+  padding: 10px 20px;
+  border-radius: 20px;
+  font-size: 16px;
+  margin-top:7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.search-button mat-icon {
+  font-size: 20px;
+}
+
+.sort-filter{
+  display: flex;
+  justify-content: center;
+}
+
+.sort-section {
+  margin-right: 30px;
+  display: flex;
+  gap: 20px;
+}
+
+.filter-section{
+  margin-left:30px;
+}
+
+
+.reset-button{
+  margin-left: 10px;
+  background-color: #c8b7e4 !important;
+  border:none;
+}
+
+
+.all-events-section{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 20px;
+  padding-bottom:20px;
+  text-align: center;
+  z-index: 1;
+  padding-bottom: 20px;
+  background-color: #dddddd;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.all-event-cards {
+  display: grid;
+  width: 100%;
+  padding-top:30px;
+  flex-wrap: wrap;
+  justify-content: center;
+  grid-template-columns: repeat(auto-fit,minmax(450px,450px));
+
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+.pagination p{
+  margin:0;
+  color: gray;
+  font-family: 'Roboto','serif';
+}
+
+.pagination button {
+  padding: 10px 15px;
+  color: #545283;
+  border: 1px solid #ddd;
+  background-color: #f2eef6;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.pagination button:hover {
+  background-color: #9c9ac9;
+  color: #fff;
+}
+
+button[disabled] {
+  background-color: #bcbcbc;
+  color: #9e9e9e;
+  box-shadow: none;
+  opacity: 0.7;
+}
+
+.footer {
+  background-color: #d0cfe1;
+  color: #3A2D30;
+  padding: 20px 0;
+}
+
+.footer-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.footer-info h1,
+.footer-social h1 {
+  font-size: 2em;
+  margin-bottom: 10px;
+  color:#3A2D30;
+}
+
+.footer-info p,
+.footer-social .social-icons {
+  margin: 5px 0;
+  display: flex;
+  align-items: center;
+}
+
+.footer-info p mat-icon,
+.footer-social .social-icons mat-icon {
+  margin-right: 10px;
+  font-size: 1.5em;
+  color: #3A2D30;
+}
+
+.footer-social .social-icons mat-icon {
+  cursor: pointer;
+}
+
+.custom-icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 15px;
+  cursor: pointer;
+}
+
+.custom-icon:hover {
+  filter: brightness(85%);
+}
+
+.add-to-favorite {
+  text-align: center;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: transparent;
+  border: none;
+}
+.add-to-favorite button{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  height: 64px;
+  width: 48px;
+}
+
+.event-bg{
+  background-color: #d0cfe1;
+}
+
+.offering-bg{
+  background-color: #d0cfe1;
+}
+
+::ng-deep .mat-mdc-button:not(:disabled){
+  background-color: white !important ;
+  color: #000000 !important;
+}
+::ng-deep .mat-mdc-button:not(:disabled):hover{
+  background-color: #bebce6 !important ;
+  color: white !important;
+}
+::ng-deep .mat-mdc-snack-bar-container .mat-mdc-snackbar-surface{
+  background-color: #fff !important; /* Change background color */
+  color: #000000 !important; /* Change text color */
+}
+
+.offering-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 8px;
+}

--- a/EventPlanner/src/app/user/favourites/favourites.component.html
+++ b/EventPlanner/src/app/user/favourites/favourites.component.html
@@ -21,3 +21,27 @@
     </div>
   </div>
 </div>
+
+<div class="all-events">
+  <div class="all-events-section">
+    <h2>Your Favourite Offerings</h2>
+    <div class="no-events-message" *ngIf="noOfferingsMessage">
+      <p>{{ noOfferingsMessage }}</p>
+    </div>
+    <div class="all-event-cards">
+      <app-offering-card *ngFor="let offering of favouriteOfferings" [offering]="offering"></app-offering-card>
+    </div>
+    <p class="total-elements">Total elements: {{ offeringPageProperties.totalElements }}</p>
+    <div class="pagination" *ngIf="!noOfferingsMessage">
+      <button mat-stroked-button (click)="previousOfferingPage()" [disabled]="offeringPageProperties.page === 0">
+        &lt;
+      </button>
+      <p>
+        Page {{ offeringPageProperties.page + 1 }} of {{ offeringPageProperties.totalPages }}
+      </p>
+      <button mat-stroked-button (click)="nextOfferingPage()" [disabled]="offeringPageProperties.page === offeringPageProperties.totalPages - 1">
+        &gt;
+      </button>
+    </div>
+  </div>
+</div>

--- a/EventPlanner/src/app/user/favourites/favourites.component.html
+++ b/EventPlanner/src/app/user/favourites/favourites.component.html
@@ -1,0 +1,23 @@
+<div class="all-events">
+  <div class="all-events-section">
+    <h2>Your Favourite Events</h2>
+    <div class="no-events-message" *ngIf="noEventsMessage">
+      <p>{{ noEventsMessage }}</p>
+    </div>
+    <div class="all-event-cards">
+      <app-event-card *ngFor="let event of favouriteEvents" [event]="event"></app-event-card>
+    </div>
+    <p class="total-elements">Total elements: {{ eventPageProperties.totalElements }}</p>
+    <div class="pagination" *ngIf="!noEventsMessage">
+      <button mat-stroked-button (click)="previousEventPage()" [disabled]="eventPageProperties.page === 0">
+        &lt;
+      </button>
+      <p>
+        Page {{ eventPageProperties.page + 1 }} of {{ eventPageProperties.totalPages }}
+      </p>
+      <button mat-stroked-button (click)="nextEventPage()" [disabled]="eventPageProperties.page === eventPageProperties.totalPages - 1">
+        &gt;
+      </button>
+    </div>
+  </div>
+</div>

--- a/EventPlanner/src/app/user/favourites/favourites.component.spec.ts
+++ b/EventPlanner/src/app/user/favourites/favourites.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FavouritesComponent } from './favourites.component';
+
+describe('FavouritesComponent', () => {
+  let component: FavouritesComponent;
+  let fixture: ComponentFixture<FavouritesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FavouritesComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FavouritesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/EventPlanner/src/app/user/favourites/favourites.component.ts
+++ b/EventPlanner/src/app/user/favourites/favourites.component.ts
@@ -1,0 +1,65 @@
+import {Component, OnInit} from '@angular/core';
+import {AccountService} from '../../account/account.service';
+import { Event } from '../../event/model/event.model';
+
+@Component({
+  selector: 'app-favourites',
+  templateUrl: './favourites.component.html',
+  styleUrl: './favourites.component.css'
+})
+export class FavouritesComponent implements OnInit{
+  eventPageProperties = {
+    page: 0,
+    pageSize: 6,
+    totalPages: 0,
+    totalElements: 0
+  };
+
+  offeringPageProperties = {
+    page: 0,
+    pageSize: 6,
+    totalPages: 0,
+    totalElements: 0
+  };
+  favouriteEvents: Event[] = [];
+  noEventsMessage: string = '';
+  noOfferingsMessage: string = '';
+
+  constructor(
+    private accountService:AccountService
+  ) {}
+
+  ngOnInit(): void {
+    this.fetchFavouriteEvents();
+  }
+
+  fetchFavouriteEvents(): void {
+    const { page, pageSize } = this.eventPageProperties;
+
+    this.accountService.getFavouriteEvents(page, pageSize).subscribe({
+      next: (response) => {
+        this.favouriteEvents = response.content;
+        this.eventPageProperties.totalPages = response.totalPages;
+        this.eventPageProperties.totalElements = response.totalElements;
+        this.noEventsMessage = this.favouriteEvents.length ? '' : 'No events found.';
+      },
+      error: () => {
+        this.noEventsMessage = 'An error occurred while fetching events.';
+      }
+    });
+  }
+
+  nextEventPage(): void {
+    if (this.eventPageProperties.page < this.eventPageProperties.totalPages - 1) {
+      this.eventPageProperties.page++;
+      this.fetchFavouriteEvents();
+    }
+  }
+
+  previousEventPage(): void {
+    if (this.eventPageProperties.page > 0) {
+      this.eventPageProperties.page--;
+      this.fetchFavouriteEvents();
+    }
+  }
+}

--- a/EventPlanner/src/app/user/favourites/favourites.component.ts
+++ b/EventPlanner/src/app/user/favourites/favourites.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {AccountService} from '../../account/account.service';
 import { Event } from '../../event/model/event.model';
+import {Offering} from '../../offering/model/offering.model';
 
 @Component({
   selector: 'app-favourites',
@@ -22,6 +23,7 @@ export class FavouritesComponent implements OnInit{
     totalElements: 0
   };
   favouriteEvents: Event[] = [];
+  favouriteOfferings:Offering[]=[];
   noEventsMessage: string = '';
   noOfferingsMessage: string = '';
 
@@ -31,6 +33,7 @@ export class FavouritesComponent implements OnInit{
 
   ngOnInit(): void {
     this.fetchFavouriteEvents();
+    this.fetchFavouriteOfferings();
   }
 
   fetchFavouriteEvents(): void {
@@ -60,6 +63,35 @@ export class FavouritesComponent implements OnInit{
     if (this.eventPageProperties.page > 0) {
       this.eventPageProperties.page--;
       this.fetchFavouriteEvents();
+    }
+  }
+
+  fetchFavouriteOfferings(): void {
+    const { page, pageSize } = this.offeringPageProperties;
+    this.accountService.getFavouriteOfferings(page, pageSize).subscribe({
+      next: (response) => {
+        this.favouriteOfferings = response.content;
+        this.offeringPageProperties.totalPages = response.totalPages;
+        this.offeringPageProperties.totalElements = response.totalElements;
+        this.noOfferingsMessage = this.favouriteOfferings.length ? '' : 'No offerings found.';
+      },
+      error: () => {
+        this.noOfferingsMessage = 'An error occurred while fetching offerings.';
+      }
+    });
+  }
+
+  nextOfferingPage(): void {
+    if (this.offeringPageProperties.page < this.offeringPageProperties.totalPages - 1) {
+      this.offeringPageProperties.page++;
+      this.fetchFavouriteOfferings();
+    }
+  }
+
+  previousOfferingPage(): void {
+    if (this.offeringPageProperties.page > 0) {
+      this.offeringPageProperties.page--;
+      this.fetchFavouriteOfferings();
     }
   }
 }

--- a/EventPlanner/src/app/user/user.module.ts
+++ b/EventPlanner/src/app/user/user.module.ts
@@ -16,6 +16,7 @@ import {MatOption} from '@angular/material/core';
 import {MatSelect} from '@angular/material/select';
 import { FavouritesComponent } from './favourites/favourites.component';
 import {EventModule} from '../event/event.module';
+import {OfferingModule} from '../offering/offering.module';
 
 
 
@@ -42,7 +43,8 @@ import {EventModule} from '../event/event.module';
     MatDialogTitle,
     MatOption,
     MatSelect,
-    EventModule
+    EventModule,
+    OfferingModule
   ]
 })
 export class UserModule { }

--- a/EventPlanner/src/app/user/user.module.ts
+++ b/EventPlanner/src/app/user/user.module.ts
@@ -14,6 +14,8 @@ import { ChangePasswordComponent } from './change-password/change-password.compo
 import {MatDialogActions, MatDialogContent, MatDialogTitle} from '@angular/material/dialog';
 import {MatOption} from '@angular/material/core';
 import {MatSelect} from '@angular/material/select';
+import { FavouritesComponent } from './favourites/favourites.component';
+import {EventModule} from '../event/event.module';
 
 
 
@@ -22,7 +24,8 @@ import {MatSelect} from '@angular/material/select';
     UserDetailsComponent,
     EditPersonalComponent,
     EditCompanyComponent,
-    ChangePasswordComponent
+    ChangePasswordComponent,
+    FavouritesComponent
   ],
   imports: [
     CommonModule,
@@ -38,7 +41,8 @@ import {MatSelect} from '@angular/material/select';
     MatDialogContent,
     MatDialogTitle,
     MatOption,
-    MatSelect
+    MatSelect,
+    EventModule
   ]
 })
 export class UserModule { }


### PR DESCRIPTION
This pull request introduces a new "Favourites" feature to the EventPlanner application, allowing users to view and manage their favorite events and offerings.

### Service Changes for Favourites Feature:
* Updated `getFavouriteOfferings` and `getFavouriteEvents` methods to support pagination and return paged responses. Added new methods `getFavouriteOffering` and `getFavouriteEvent` to fetch individual favorites. Removed `isInFavouriteOfferings` and `isInFavouriteEvents` methods.

### New Components for Favourites:
* Created a new `FavouritesComponent` to display paginated lists of favorite events and offerings. Added methods for fetching and navigating between pages.

### Refactoring and Cleanup:
* Refactored logic to check if an event is a favorite by using `getFavouriteEvent` instead of `isInFavouriteEvents`. Removed unnecessary `console.log` statements.  
* Refactored logic to check if an offering is a favorite by using `getFavouriteOffering` instead of `isInFavouriteOfferings`. Removed redundant code. 
