### PR TITLE
Add User Block/Unblock Functionality In Chat Component

### DIFF
--- a/EventPlanner/src/app/account/account.service.ts
+++ b/EventPlanner/src/app/account/account.service.ts
@@ -7,6 +7,7 @@ import {environment} from '../../env/environment';
 import { Offering } from '../offering/model/offering.model';
 import {PagedResponse} from '../event/model/paged-response.model';
 import {CalendarItem} from '../user/model/calendar-item.model';
+import { BlockStatusDto } from '../user/model/block-status-dto.model';
 
 @Injectable({
   providedIn: 'root'
@@ -80,5 +81,23 @@ export class AccountService {
 
   getCalendar(accountId:number):Observable<CalendarItem[]>{
     return this.httpClient.get<CalendarItem[]>(environment.apiHost+'/accounts/'+accountId+'/calendar');
+  }
+
+  blockAccount(accountId: number): Observable<void> {
+    let loggedInAccountId:number=this.authService.getAccountId();
+    if(loggedInAccountId == null)
+      return null;
+    return this.httpClient.post<void>(environment.apiHost+'/accounts/'+loggedInAccountId+'/block/'+accountId, null);
+  }
+
+  unblockAccount(accountId: number): Observable<void> {
+    let loggedInAccountId:number=this.authService.getAccountId();
+    if(loggedInAccountId == null)
+      return null;
+    return this.httpClient.delete<void>(environment.apiHost+'/accounts/'+loggedInAccountId+'/unblock/'+accountId);
+  }
+
+  isAccountBlocked(blockerId: number, blockedId: number): Observable<BlockStatusDto>{
+    return this.httpClient.get<BlockStatusDto>(environment.apiHost+'/accounts/'+blockerId+'/blocked-accounts/'+blockedId);
   }
 }

--- a/EventPlanner/src/app/chat/component/chat.component.css
+++ b/EventPlanner/src/app/chat/component/chat.component.css
@@ -296,7 +296,7 @@
   }
 }
 
-.icon-btn {
+.report-btn {
   background: transparent;
   border: none;
   cursor: pointer;
@@ -308,6 +308,50 @@
   justify-content: center;
 }
 
-.icon-btn:hover {
+.report-btn:hover {
   color: #b71c1c;
+}
+
+.block-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  font-size: 20px;
+  color: #808080;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.clock-btn:hover {
+  color: #5b5b5b;
+}
+
+.action-buttons {
+  display: flex;
+  justify-content: center;
+}
+
+
+.chat-messages.blurred {
+  filter: blur(4px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.block-overlay {
+  position: relative;
+  top: 30%;
+  left: 50%;
+  z-index: 10;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 1.5rem 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.15);
+  font-size: 1.2rem;
+  color: #333;
+  text-align: center;
+  max-width: 50%;
 }

--- a/EventPlanner/src/app/chat/component/chat.component.html
+++ b/EventPlanner/src/app/chat/component/chat.component.html
@@ -27,14 +27,20 @@
   <div class="chat-container" *ngIf="selectedContactId">
     <div class="chat-header">
       <h3>{{ getSelectedContactName() }}</h3>
-      <div *ngIf="getSelectedContactName()">
-            <button class="icon-btn report" (click)="reportAccount(selectedContactId)" >
+      <div *ngIf="getSelectedContactName()" class="action-buttons">
+            <button class="report-btn report" (click)="reportAccount(selectedContactId)" >
                 <mat-icon>flag</mat-icon>
+            </button>
+            <button class="block-btn" (click)="blockAccount(selectedContactId)" >
+                <mat-icon>block</mat-icon>
             </button>
       </div>
     </div>
     
-    <div class="chat-messages" #scrollMe>
+    <div class="block-overlay" *ngIf="isChatterBlocked">
+      {{chatterBlockedMsg}}
+    </div>
+    <div class="chat-messages" #scrollMe [class.blurred]="isChatterBlocked">
       <ng-container *ngFor="let message of messages">
         <div class="message-row"
              [class.sent]="isSentByCurrentUser(message.senderId)"
@@ -51,8 +57,8 @@
     
     <div class="chat-input">
       <form [formGroup]="form" (ngSubmit)="sendMessageUsingSocket()">
-        <input type="text" formControlName="message" placeholder="Type a message...">
-        <button type="submit" [disabled]="!form.valid">Send</button>
+        <input type="text" formControlName="message" placeholder="Type a message..." [disabled]="isChatterBlocked">
+        <button type="submit" [disabled]="!form.valid || isChatterBlocked">Send</button>
       </form>
     </div>
   </div>

--- a/EventPlanner/src/app/chat/component/chat.component.ts
+++ b/EventPlanner/src/app/chat/component/chat.component.ts
@@ -12,6 +12,9 @@ import { ReportFormComponent } from '../../suspension/report-form/report-form.co
 import { SuspensionService } from '../../suspension/suspension.service';
 import { CreateAccountReportDTO } from '../../suspension/model/create-account-report-dto.model';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { ConfirmDialogComponent } from '../../layout/confirm-dialog/confirm-dialog.component';
+import { AccountService } from '../../account/account.service';
+import { firstValueFrom } from 'rxjs';
 
 export interface ChatContact {
   user: number;
@@ -35,6 +38,9 @@ export class ChatComponent implements OnInit, AfterViewChecked {
   
   loggedInUserId: number;
   selectedContactId: number | null = null;
+
+  isChatterBlocked: boolean = false;
+  chatterBlockedMsg: string = "";
   
   @ViewChild('scrollMe') private myScrollContainer!: ElementRef;
 
@@ -42,6 +48,7 @@ export class ChatComponent implements OnInit, AfterViewChecked {
     private socketService: ChatService,
     private authService: AuthService,
     private reportService: SuspensionService,
+    private accountService: AccountService,
     private dialog: MatDialog,
     private snackBar: MatSnackBar
   ) {}
@@ -97,6 +104,7 @@ export class ChatComponent implements OnInit, AfterViewChecked {
 
   loadMessages(senderId: number, receiverId: number) {
     console.log(senderId,receiverId)
+    this.checkBlockedStatus(senderId, receiverId);
     this.socketService.getMessages(senderId, receiverId).subscribe({
       next: (messages) => {
         this.messages = messages;
@@ -208,6 +216,97 @@ export class ChatComponent implements OnInit, AfterViewChecked {
         }
       });
     }
+  });
+}
+
+blockAccount(accountId: number): void {
+  // Prevent blocking back if the user has already been blocked
+  if (this.chatterBlockedMsg === "You have been blocked by this user") {
+    this.snackBar.open('You cannot block a user who has already blocked you.', 'Close', {
+      duration: 3000,
+      panelClass: ['snackbar-error']
+    });
+    return;
+  }
+
+  const isCurrentlyBlockedByYou = this.chatterBlockedMsg === "You have blocked this user";
+  const dialogMsg = isCurrentlyBlockedByYou
+    ? "Are you sure you want to unblock this account?"
+    : "Are you sure you want to block this account?";
+
+  this.dialog.open(ConfirmDialogComponent, {
+    data: {
+      message: dialogMsg
+    }
+  }).afterClosed().subscribe(result => {
+    if (result) {
+      if (isCurrentlyBlockedByYou) {
+        // Unblock flow
+        this.accountService.unblockAccount(accountId).subscribe({
+          next: () => {
+            this.snackBar.open('User unblocked successfully.', 'Close', {
+              duration: 3000,
+              panelClass: ['snackbar-success']
+            });
+            if (this.loggedInUserId && this.selectedContactId) {
+              this.checkBlockedStatus(this.loggedInUserId, this.selectedContactId);
+            }
+          },
+          error: (err) => {
+            const errorMsg = err?.error ?? 'Failed to unblock user.';
+            this.snackBar.open(errorMsg, 'Close', {
+              duration: 3000,
+              panelClass: ['snackbar-error']
+            });
+          }
+        });
+      } else {
+        // Block flow
+        this.accountService.blockAccount(accountId).subscribe({
+          next: () => {
+            this.snackBar.open('User blocked successfully.', 'Close', {
+              duration: 3000,
+              panelClass: ['snackbar-success']
+            });
+            if (this.loggedInUserId && this.selectedContactId) {
+              this.checkBlockedStatus(this.loggedInUserId, this.selectedContactId);
+            }
+          },
+          error: (err) => {
+            const errorMsg = err?.error ?? 'Failed to block user.';
+            this.snackBar.open(errorMsg, 'Close', {
+              duration: 3000,
+              panelClass: ['snackbar-error']
+            });
+          }
+        });
+      }
+    }
+  });
+}
+
+  checkBlockedStatus(senderId: number, receiverId: number): void {
+  const blockedByYou$ = this.accountService.isAccountBlocked(senderId, receiverId);
+  const blockedByOther$ = this.accountService.isAccountBlocked(receiverId, senderId);
+
+  Promise.all([
+    firstValueFrom(blockedByYou$),
+    firstValueFrom(blockedByOther$)
+  ]).then(([youBlocked, theyBlocked]) => {
+    if (youBlocked.blocked) {
+      this.chatterBlockedMsg = "You have blocked this user";
+      this.isChatterBlocked = true;
+    } else if (theyBlocked.blocked) {
+      this.chatterBlockedMsg = "You have been blocked by this user";
+      this.isChatterBlocked = true;
+    } else {
+      this.chatterBlockedMsg = "";
+      this.isChatterBlocked = false;
+    }
+  }).catch(err => {
+    console.error('Error checking blocked status:', err);
+    this.chatterBlockedMsg = "";
+    this.isChatterBlocked = false;
   });
 }
 

--- a/EventPlanner/src/app/event/event-details/event-details.component.ts
+++ b/EventPlanner/src/app/event/event-details/event-details.component.ts
@@ -272,6 +272,7 @@ export class EventDetailsComponent implements OnInit {
       const fileName = this.event?.organizer?.profilePhoto.split('\\').pop()?.split('/').pop();
       return `${environment.apiHost}/images/${fileName}`
     }
+  }
     
   reportAccount(accountId: number): void {
     this.dialog.open(ReportFormComponent, {

--- a/EventPlanner/src/app/event/event.service.ts
+++ b/EventPlanner/src/app/event/event.service.ts
@@ -21,9 +21,6 @@ import { GuestList } from './model/guest-list.model';
   providedIn: 'root'
 })
 export class EventService {
-  private eventList: Event[] = [];
-  private topEventList: Event[] = [];
-
   constructor(private httpClient: HttpClient) {}
 
   getAll(): Observable<Event[]> {

--- a/EventPlanner/src/app/event/event.service.ts
+++ b/EventPlanner/src/app/event/event.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
-import { map, Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Event } from './model/event.model';
-import {CreateEventTypeDTO} from './model/create-event-type-dto.model';
-import {EventType} from './model/event-type.model';
 import {environment} from '../../env/environment';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {CreateEventDTO} from './model/create-event-dto.model';

--- a/EventPlanner/src/app/layout/home/home.component.ts
+++ b/EventPlanner/src/app/layout/home/home.component.ts
@@ -260,10 +260,11 @@ export class HomeComponent implements OnInit {
   fetchPaginatedEvents(): void {
     const { page, pageSize } = this.eventPageProperties;
     if (this.initialLoadEvents){
-      this.eventFilters = { ...this.eventFilters, ...{accountId: this.accountId} };
+      this.eventFilters = { ...this.eventFilters, ...{initLoad: true} };
     }else{
-      delete this.eventFilters.accountId;
+      delete this.eventFilters.initLoad;
     }
+    this.eventFilters = { ...this.eventFilters, ...{accountId: this.accountId} };
     this.eventService.getPaginatedEvents(page, pageSize, this.eventFilters).subscribe({
       next: (response) => {
         this.allEvents = response.content;
@@ -285,10 +286,11 @@ export class HomeComponent implements OnInit {
   fetchPaginatedOfferings(): void {
     const { page, pageSize } = this.offeringPageProperties;
     if (this.initialLoadOfferings){
-      this.offeringFilters = { ...this.offeringFilters, ...{accountId: this.accountId} };
+      this.offeringFilters = { ...this.offeringFilters, ...{initLoad: this.initialLoadOfferings} };
     }else{
-      delete this.offeringFilters.accountId;
+      delete this.offeringFilters.initLoad;
     }
+    this.offeringFilters = { ...this.offeringFilters, ...{accountId: this.accountId} };
     if (this.selectedOfferingType!==null){
       this.offeringFilters.isServiceFilter = this.selectedOfferingType === 'services';
     }

--- a/EventPlanner/src/app/user/model/block-status-dto.model.ts
+++ b/EventPlanner/src/app/user/model/block-status-dto.model.ts
@@ -1,0 +1,3 @@
+export interface BlockStatusDto {
+  blocked: boolean;
+}


### PR DESCRIPTION
This PR introduces support for user blocking and unblocking directly from the chat interface. It also adds backend integration for managing blocked status between users.

* **Chat component**

  * Added block/unblock button in the UI
  * Disabled message input and blurred chat when blocked
  * Informative overlay message when blocked
  * Logic to handle both "You blocked" and "You were blocked" cases
  * Confirmation dialogs for block/unblock actions
* **Account service**

  * New methods:

    * `blockAccount(accountId: number)`
    * `unblockAccount(accountId: number)`
    * `isAccountBlocked(blockerId: number, blockedId: number)`
* **DTOs**

  * Added `BlockStatusDto` interface
* **Styling**

  * Added styles for `.block-btn`, `.block-overlay`, and chat blur effect
* **Home component**

  * Adjusted filter logic during initial load of events/offerings
* **Minor fixes**

  * Removed unused imports