### PR TITLE
Implement registration unit tests

### DIFF
--- a/EventPlanner/src/app/event/create-agenda-item/create-agenda-item.component.html
+++ b/EventPlanner/src/app/event/create-agenda-item/create-agenda-item.component.html
@@ -23,7 +23,7 @@
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>End time</mat-label>
         <input type="time" matInput formControlName="endTime" required>
-        <mat-error *ngIf="createForm.errors!=null && createForm.errors['time']">End time must be after start time</mat-error>
+        <mat-error *ngIf="createForm.hasError('timeInvalid')">End time must be after start time</mat-error>
       </mat-form-field>
 
       <mat-form-field appearance="outline" class="full-width">

--- a/EventPlanner/src/app/event/create-agenda-item/create-agenda-item.component.ts
+++ b/EventPlanner/src/app/event/create-agenda-item/create-agenda-item.component.ts
@@ -49,20 +49,21 @@ export function TimeValidator(startTimeControlName: string, endTimeControlName: 
     const endTimeControl = formGroup.get(endTimeControlName);
 
     if (!startTimeControl || !endTimeControl) {
-      return null; // Return null if controls are missing
+      return null; // Controls missing, nothing to validate
     }
 
-    if (startTimeControl.errors && !endTimeControl.errors['time']) {
-      return null; // Skip if another validator has found an error
+    // If other validators found errors on controls, don't override
+    if (startTimeControl.errors || endTimeControl.errors) {
+      return null;
     }
 
-    if (startTimeControl.value >= endTimeControl.value) {
-      endTimeControl.setErrors({ time: true });
-      return { time: true };
-    } else {
-      endTimeControl.setErrors(null);
+    if (startTimeControl.value && endTimeControl.value && startTimeControl.value >= endTimeControl.value) {
+      // Return error object at form group level
+      return { timeInvalid: true };
     }
 
+    // No errors
     return null;
   };
 }
+

--- a/EventPlanner/src/app/event/create-event/create-event.component.html
+++ b/EventPlanner/src/app/event/create-event/create-event.component.html
@@ -52,7 +52,7 @@
         <mat-button-toggle value="open">Open</mat-button-toggle>
         <mat-button-toggle value="closed">Closed</mat-button-toggle>
       </mat-button-toggle-group>
-      <button mat-flat-button class="submit-btn"  (click)="save()">
+      <button mat-flat-button class="submit-btn"  (click)="save()" [disabled]="!createForm.valid">
         Submit
       </button>
     </form>

--- a/EventPlanner/src/app/event/create-event/create-event.component.ts
+++ b/EventPlanner/src/app/event/create-event/create-event.component.ts
@@ -94,7 +94,7 @@ export class CreateEventComponent implements OnInit{
       this.eventService.add(event).subscribe({
         next: (createdEvent) => {
           this.snackBar.open('Event created successfully','OK',{duration:3000});
-          this.router.navigate(['home']);
+          this.router.navigate(['event',createdEvent.id]);
         },
         error: () => {
           this.snackBar.open('Error creating event','OK',{duration:3000});

--- a/EventPlanner/src/app/event/edit-event/edit-event.component.html
+++ b/EventPlanner/src/app/event/edit-event/edit-event.component.html
@@ -52,7 +52,7 @@
         <mat-button-toggle value="open">Open</mat-button-toggle>
         <mat-button-toggle value="closed">Closed</mat-button-toggle>
       </mat-button-toggle-group>
-      <button mat-flat-button class="submit-btn" (click)="save()">
+      <button mat-flat-button class="submit-btn" (click)="save()" [disabled]="!editForm.valid">
         Submit
       </button>
     </form>

--- a/EventPlanner/src/app/infrastructure/auth/auth.service.spec.ts
+++ b/EventPlanner/src/app/infrastructure/auth/auth.service.spec.ts
@@ -1,16 +1,147 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpParams } from '@angular/common/http';
 
 import { AuthService } from './auth.service';
+import { RegisterDTO } from './model/register-dto.model';
+import { environment } from '../../../env/environment';
 
-describe('AuthService', () => {
+describe('AuthService - register function', () => {
   let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  const mockRegisterDTO: RegisterDTO = {
+    email: 'test@example.com',
+    password: 'password123',
+    firstName: 'John',
+    lastName: 'Doe',
+    location: {
+      country: 'USA',
+      city: 'New York',
+      street: 'Main St',
+      houseNumber: '123'
+    },
+    phoneNumber: '1234567890',
+    role: 'EVENT_ORGANIZER',
+    company: null
+  };
+
+  const mockRegisterWithCompanyDTO: RegisterDTO = {
+    email: 'provider@example.com',
+    password: 'password123',
+    firstName: 'Jane',
+    lastName: 'Smith',
+    location: {
+      country: 'USA',
+      city: 'Boston',
+      street: 'Business Ave',
+      houseNumber: '456'
+    },
+    phoneNumber: '0987654321',
+    role: 'PROVIDER',
+    company: {
+      email: 'company@example.com',
+      name: 'Test Company',
+      location: {
+        country: 'USA',
+        city: 'Boston',
+        street: 'Business Ave',
+        houseNumber: '456'
+      },
+      phoneNumber: '0987654321',
+      description: 'Test company description'
+    }
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService]
+    });
+
     service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('register', () => {
+    it('should make POST request to correct endpoint', () => {
+      service.register(mockRegisterDTO, false).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      expect(req.request.method).toBe('POST');
+      req.flush(mockRegisterDTO);
+    });
+
+    it('should send correct body data', () => {
+      service.register(mockRegisterDTO, false).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      expect(req.request.body).toEqual(mockRegisterDTO);
+      req.flush(mockRegisterDTO);
+    });
+
+    it('should set roleUpgrade parameter to false when roleUpgrade is false', () => {
+      service.register(mockRegisterDTO, false).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      expect(req.request.params.get('roleUpgrade')).toBe('false');
+      req.flush(mockRegisterDTO);
+    });
+
+    it('should set roleUpgrade parameter to true when roleUpgrade is true', () => {
+      service.register(mockRegisterDTO, true).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=true`);
+      expect(req.request.params.get('roleUpgrade')).toBe('true');
+      req.flush(mockRegisterDTO);
+    });
+
+    it('should return observable with RegisterDTO on successful registration', () => {
+      const expectedResponse: RegisterDTO = { ...mockRegisterDTO };
+
+      service.register(mockRegisterDTO, false).subscribe(response => {
+        expect(response).toEqual(expectedResponse);
+      });
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      req.flush(expectedResponse);
+    });
+
+    it('should handle registration with company data', () => {
+      service.register(mockRegisterWithCompanyDTO, false).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      expect(req.request.body).toEqual(mockRegisterWithCompanyDTO);
+      expect(req.request.body.company).toBeTruthy();
+      expect(req.request.body.company.name).toBe('Test Company');
+      req.flush(mockRegisterWithCompanyDTO);
+    });
+
+    it('should handle registration without company data', () => {
+      service.register(mockRegisterDTO, false).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=false`);
+      expect(req.request.body).toEqual(mockRegisterDTO);
+      expect(req.request.body.company).toBeNull();
+      req.flush(mockRegisterDTO);
+    });
+
+    it('should handle role upgrade scenario', () => {
+      const roleUpgradeDTO: RegisterDTO = {
+        ...mockRegisterDTO,
+        password: null // No password needed for role upgrade
+      };
+
+      service.register(roleUpgradeDTO, true).subscribe();
+
+      const req = httpMock.expectOne(`${environment.apiHost}/auth/register?roleUpgrade=true`);
+      expect(req.request.body.password).toBeNull();
+      expect(req.request.params.get('roleUpgrade')).toBe('true');
+      req.flush(roleUpgradeDTO);
+    });
   });
 });

--- a/EventPlanner/src/app/infrastructure/auth/model/create-company-dto.model.ts
+++ b/EventPlanner/src/app/infrastructure/auth/model/create-company-dto.model.ts
@@ -6,5 +6,5 @@ export interface CreateCompanyDTO {
   location:CreateLocationDTO
   phoneNumber: string;
   description: string;
-  photos: string[];
+  photos?: string[];
 }

--- a/EventPlanner/src/app/infrastructure/auth/model/register-dto.model.ts
+++ b/EventPlanner/src/app/infrastructure/auth/model/register-dto.model.ts
@@ -6,7 +6,7 @@ export interface RegisterDTO {
   password: string;
   firstName: string;
   lastName: string;
-  profilePhoto: string;
+  profilePhoto?: string;
   location:CreateLocationDTO;
   phoneNumber: string;
   company:CreateCompanyDTO;

--- a/EventPlanner/src/app/infrastructure/auth/register/register.component.html
+++ b/EventPlanner/src/app/infrastructure/auth/register/register.component.html
@@ -50,16 +50,6 @@
         <mat-label>Phone</mat-label>
         <input matInput formControlName="phone" name="phone">
       </mat-form-field>
-      <div class="form-section photo-upload">
-        <mat-label>Profile photo</mat-label>
-        <div class="upload-container">
-          <input type="file" #profilePhotoInput (change)="onProfilePhotoUpload()" accept="image/*" class="file-input">
-          <div class="upload-area" (click)="profilePhotoInput.click()">
-            <mat-icon class="upload-icon">cloud_upload</mat-icon>
-            <p>Click to Upload Photo</p>
-          </div>
-        </div>
-      </div>
       <p>Select role:</p>
       <mat-radio-group color="primary" aria-label="Select role" formControlName="role" name="role">
         <mat-radio-button color="primary" value="organizer">Event organizer</mat-radio-button>
@@ -101,18 +91,8 @@
           <mat-label>Description</mat-label>
           <textarea matInput rows="4" placeholder="Enter description" formControlName="companyDescription" name="companyDescription"></textarea>
         </mat-form-field>
-        <div class="form-section photo-upload">
-          <mat-label>Company photos (optional)</mat-label>
-          <div class="upload-container">
-            <input type="file" #companyPhotosInput multiple (change)="onCompanyPhotosUpload()" accept="image/*" class="file-input">
-            <div class="upload-area" (click)="companyPhotosInput.click()">
-              <mat-icon class="upload-icon">cloud_upload</mat-icon>
-              <p>Click to Upload Photos</p>
-            </div>
-          </div>
-        </div>
       </div>
-      <button mat-flat-button class="submit-btn"  (click)="register()">
+      <button mat-flat-button class="submit-btn"  (click)="register()" [disabled]="(companyInfoRequired() && !registerForm.valid) || (!companyInfoRequired() && !isOrganizerFormValid())">
         Register
       </button>
     </form>

--- a/EventPlanner/src/app/infrastructure/auth/register/register.component.spec.ts
+++ b/EventPlanner/src/app/infrastructure/auth/register/register.component.spec.ts
@@ -1,23 +1,432 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
 
 import { RegisterComponent } from './register.component';
+import { AuthService } from '../auth.service';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {MatInputModule} from '@angular/material/input';
+import {MatButtonModule} from '@angular/material/button';
+import {MatRadioModule} from '@angular/material/radio';
+import {MatIconModule} from '@angular/material/icon';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    const authServiceSpy = jasmine.createSpyObj('AuthService', ['register', 'getEmail', 'setUser']);
+    const snackBarSpy = jasmine.createSpyObj('MatSnackBar', ['open']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      declarations: [RegisterComponent]
-    })
-    .compileComponents();
+      declarations: [RegisterComponent],
+      imports: [ReactiveFormsModule,
+        BrowserAnimationsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatRadioModule,
+        MatIconModule,
+        MatSnackBarModule],
+      providers: [
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: MatSnackBar, useValue: snackBarSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    snackBar = TestBed.inject(MatSnackBar) as jasmine.SpyObj<MatSnackBar>;
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should set roleUpgrade to false when no email exists', () => {
+      authService.getEmail.and.returnValue(null);
+
+      component.ngOnInit();
+
+      expect(component.roleUpgrade).toBeFalsy();
+      expect(component.registerForm.get('password')).toBeTruthy();
+      expect(component.registerForm.get('confirmPassword')).toBeTruthy();
+    });
+
+    it('should set roleUpgrade to true and modify form when email exists', () => {
+      authService.getEmail.and.returnValue('test@example.com');
+
+      component.ngOnInit();
+
+      expect(component.roleUpgrade).toBeTruthy();
+      expect(component.registerForm.get('password')).toBeFalsy();
+      expect(component.registerForm.get('confirmPassword')).toBeFalsy();
+      expect(component.registerForm.get('email')?.value).toBe('test@example.com');
+    });
+  });
+
+  describe('Form Validation', () => {
+    beforeEach(() => {
+      authService.getEmail.and.returnValue(null);
+      component.ngOnInit();
+    });
+
+    it('should be invalid when all fields are empty', () => {
+      expect(component.registerForm.valid).toBeFalsy();
+    });
+
+    it('should be invalid with invalid email format', () => {
+      component.registerForm.patchValue({
+        email: 'invalid-email',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      expect(component.registerForm.get('email')?.valid).toBeFalsy();
+      expect(component.registerForm.get('email')?.errors?.['email']).toBeTruthy();
+    });
+
+    it('should be invalid when password is too short', () => {
+      component.registerForm.patchValue({
+        password: '123',
+        confirmPassword: '123'
+      });
+
+      expect(component.registerForm.get('password')?.valid).toBeFalsy();
+      expect(component.registerForm.get('password')?.errors?.['minlength']).toBeTruthy();
+    });
+
+    it('should be invalid when passwords do not match', () => {
+      component.registerForm.patchValue({
+        password: 'password123',
+        confirmPassword: 'password456'
+      });
+
+      expect(component.registerForm.errors?.['mismatch']).toBeTruthy();
+    });
+
+    it('should be valid with all required organizer fields filled correctly', () => {
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      expect(component.isOrganizerFormValid()).toBeTruthy();
+    });
+  });
+
+  describe('companyInfoRequired', () => {
+    it('should return true when role is provider', () => {
+      component.registerForm.patchValue({ role: 'provider' });
+
+      expect(component.companyInfoRequired()).toBeTruthy();
+    });
+
+    it('should return false when role is organizer', () => {
+      component.registerForm.patchValue({ role: 'organizer' });
+
+      expect(component.companyInfoRequired()).toBeFalsy();
+    });
+
+    it('should return false when no role is selected', () => {
+      component.registerForm.patchValue({ role: '' });
+
+      expect(component.companyInfoRequired()).toBeFalsy();
+    });
+  });
+
+  describe('isOrganizerFormValid', () => {
+    beforeEach(() => {
+      authService.getEmail.and.returnValue(null);
+      component.ngOnInit();
+    });
+
+    it('should return false when required fields are missing', () => {
+      component.registerForm.patchValue({
+        firstName: '',
+        lastName: 'Doe'
+      });
+
+      expect(component.isOrganizerFormValid()).toBeFalsy();
+    });
+
+    it('should return true when all organizer fields are valid', () => {
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890'
+      });
+
+      expect(component.isOrganizerFormValid()).toBeTruthy();
+    });
+
+    it('should not check password fields when roleUpgrade is true', () => {
+      authService.getEmail.and.returnValue('test@example.com');
+      component.ngOnInit();
+
+      component.registerForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890'
+      });
+
+      expect(component.isOrganizerFormValid()).toBeTruthy();
+    });
+  });
+
+  describe('register', () => {
+    beforeEach(() => {
+      authService.getEmail.and.returnValue(null);
+      component.ngOnInit();
+    });
+
+    it('should call authService.register with correct organizer data', () => {
+      authService.register.and.returnValue(of(null));
+
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      component.register();
+
+      expect(authService.register).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          email: 'test@example.com',
+          password: 'password123',
+          firstName: 'John',
+          lastName: 'Doe',
+          role: 'EVENT_ORGANIZER',
+          company: null
+        }),
+        false
+      );
+    });
+
+    it('should call authService.register with correct provider data including company', () => {
+      authService.register.and.returnValue(of(null));
+
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'provider',
+        companyEmail: 'company@example.com',
+        companyName: 'Test Company',
+        companyCountry: 'USA',
+        companyCity: 'Boston',
+        companyStreet: 'Business Ave',
+        companyHouseNumber: '456',
+        companyPhone: '0987654321',
+        companyDescription: 'Test company description'
+      });
+
+      component.register();
+
+      expect(authService.register).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          email: 'test@example.com',
+          password: 'password123',
+          firstName: 'John',
+          lastName: 'Doe',
+          role: 'PROVIDER',
+          company: jasmine.objectContaining({
+            email: 'company@example.com',
+            name: 'Test Company',
+            description: 'Test company description'
+          })
+        }),
+        false
+      );
+    });
+
+    it('should show success message and navigate on successful registration', () => {
+      authService.register.and.returnValue(of(null));
+
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      component.register();
+
+      expect(snackBar.open).toHaveBeenCalledWith('Registration successful!', 'OK', { duration: 5000 });
+      expect(router.navigate).toHaveBeenCalledWith(['home']);
+    });
+
+    it('should set email conflict error on 409 response', () => {
+      const errorResponse = new HttpErrorResponse({
+        status: 409,
+        statusText: 'Conflict'
+      });
+      authService.register.and.returnValue(throwError(() => errorResponse));
+
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      component.register();
+
+      expect(component.registerForm.controls.email.errors?.['conflict']).toBeTruthy();
+    });
+
+    it('should not call register when organizer form is invalid', () => {
+      component.registerForm.patchValue({
+        email: '',
+        firstName: 'John'
+      });
+
+      component.register();
+
+      expect(authService.register).not.toHaveBeenCalled();
+    });
+
+    it('should not call register when provider form is invalid', () => {
+      component.registerForm.patchValue({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'provider',
+        companyEmail: '' // Missing required company field
+      });
+
+      component.register();
+
+      expect(authService.register).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('MatchValidator', () => {
+    it('should return null when passwords match', () => {
+      component.registerForm.patchValue({
+        password: 'password123',
+        confirmPassword: 'password123'
+      });
+
+      expect(component.registerForm.errors).toBeNull();
+    });
+
+    it('should return mismatch error when passwords do not match', () => {
+      component.registerForm.patchValue({
+        password: 'password123',
+        confirmPassword: 'password456'
+      });
+
+      expect(component.registerForm.errors?.['mismatch']).toBeTruthy();
+      expect(component.registerForm.get('confirmPassword')?.errors?.['mismatch']).toBeTruthy();
+    });
+  });
+
+  describe('Role Upgrade', () => {
+    it('should handle role upgrade registration correctly', () => {
+      authService.getEmail.and.returnValue('existing@example.com');
+      authService.register.and.returnValue(of(null));
+      component.ngOnInit();
+
+      component.registerForm.patchValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        country: 'USA',
+        city: 'New York',
+        street: 'Main St',
+        houseNumber: '123',
+        phone: '1234567890',
+        role: 'organizer'
+      });
+
+      component.register();
+
+      expect(authService.register).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          email: 'existing@example.com',
+          password: null,
+          firstName: 'John',
+          lastName: 'Doe'
+        }),
+        true
+      );
+    });
   });
 });

--- a/EventPlanner/src/app/infrastructure/auth/register/register.component.ts
+++ b/EventPlanner/src/app/infrastructure/auth/register/register.component.ts
@@ -48,14 +48,9 @@ export class RegisterComponent implements OnInit{
     { validators: MatchValidator('password', 'confirmPassword') });
   snackBar:MatSnackBar = inject(MatSnackBar);
   roleUpgrade:boolean;
-  profilePhoto:string;
-  companyPhotos:string[];
-  @ViewChild('profilePhotoInput') profilePhotoInput!: ElementRef<HTMLInputElement>;
-  @ViewChild('companyPhotosInput') companyPhotosInput!: ElementRef<HTMLInputElement>;
 
   constructor(
     private authService:AuthService,
-    private fileService:FileService,
     private router:Router) {}
 
   ngOnInit():void{
@@ -87,8 +82,7 @@ export class RegisterComponent implements OnInit{
           houseNumber: this.registerForm.value.companyHouseNumber
           },
         phoneNumber: this.registerForm.value.companyPhone,
-        description: this.registerForm.value.companyDescription,
-        photos: this.companyPhotos
+        description: this.registerForm.value.companyDescription
       }
     }
     if(!this.isOrganizerFormValid())
@@ -98,7 +92,6 @@ export class RegisterComponent implements OnInit{
       password: this.roleUpgrade? null : this.registerForm.value.password,
       firstName: this.registerForm.value.firstName,
       lastName: this.registerForm.value.lastName,
-      profilePhoto: this.profilePhoto,
       location:{
         country: this.registerForm.value.country,
         city: this.registerForm.value.city,
@@ -137,54 +130,6 @@ export class RegisterComponent implements OnInit{
         return false;
     }
     return true;
-  }
-
-  onProfilePhotoUpload() {
-    const files = this.profilePhotoInput.nativeElement.files;
-    if (files.length > 0) {
-      this.uploadProfilePhoto(files);
-    }
-  }
-
-  uploadProfilePhoto(files: FileList) {
-    const formData = new FormData();
-
-    formData.append('files', files[0]);
-
-    this.fileService.uploadPhotos(formData).subscribe({
-      next: (response: string[]) => {
-        this.snackBar.open('File uploaded successfully', 'OK', {duration: 3000});
-        this.profilePhoto = response[0];
-      },
-      error: (error) => {
-        this.snackBar.open('Failed to upload file', 'Dismiss', {duration: 3000});
-      }
-    });
-  }
-
-  onCompanyPhotosUpload() {
-    const files = this.companyPhotosInput.nativeElement.files;
-    if (files.length > 0) {
-      this.uploadFiles(files);
-    }
-  }
-
-  uploadFiles(files: FileList) {
-    const formData = new FormData();
-
-    for (let i = 0; i < files.length; i++) {
-      formData.append('files', files[i]);
-    }
-
-    this.fileService.uploadPhotos(formData).subscribe({
-      next: (response: string[]) => {
-        this.snackBar.open('Files uploaded successfully', 'OK', {duration: 3000});
-        this.companyPhotos = response;
-      },
-      error: (error) => {
-        this.snackBar.open('Failed to upload files', 'Dismiss', {duration: 3000});
-      }
-    });
   }
 }
 


### PR DESCRIPTION
- Key Changes:
  - auth.service.spec.ts:
    - Expanded register function tests: Added new test cases to cover various scenarios for the register method, including:
    - Verifying correct HTTP method (POST) and endpoint.
    - Ensuring accurate request body data is sent.
    - Testing the roleUpgrade query parameter for both true and false values.
    - Confirming the observable returns the expected RegisterDTO on success.
    - Specific tests for handling registration with and without company data.
    - A dedicated test for the role upgrade scenario, ensuring password is null and roleUpgrade parameter is true.
  - register.component.spec.ts:
    - Improved ngOnInit tests: Enhanced tests to verify roleUpgrade logic and form field adjustments based on the presence of an existing email.
    - Comprehensive Form Validation tests:
    - Added cases for invalid email format, short passwords, and mismatched passwords.
    - Included tests to ensure the form is invalid when fields are empty and valid when all required organizer fields are correctly filled.
    - companyInfoRequired function tests: Verified the function correctly identifies when company information is required based on the selected role.
    - isOrganizerFormValid function tests: Ensured this helper function accurately validates organizer-specific fields, including scenarios with and without password checks during role upgrade.
    - Extended register method tests:
    - Verified authService.register is called with the correct data for both organizer and provider roles (including company data).
    - Confirmed success messages are displayed and navigation occurs on successful registration.
  - Added a test case for handling email conflict (409 status) and setting the appropriate form error.
  - Ensured authService.register is not called when the form is invalid for both organizer and provider roles.
  - Dedicated MatchValidator tests: Explicitly tested the custom validator for password matching, ensuring it returns null on match and a mismatch error otherwise.
  - Role Upgrade scenario in register: Added a test to confirm the register method correctly handles role upgrade, sending null for password and true for roleUpgrade.